### PR TITLE
Threshold description bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 Summary of all changes made since the first release
 
+0.1.1 (2026-XX-XX)
+------------------
+* Updated documentation by fixing incorrect description of keywords.
+
 0.1.0 (2025-03-28)
 ------------------
 * Added option to specify maximum dayglow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ Summary of all changes made since the first release
 
 0.1.1 (2026-XX-XX)
 ------------------
-* Updated documentation by fixing incorrect description of keywords.
+* Updated documentation by fixing incorrect description of keywords and
+  updating hyperlinks
+* Updated xarray objects to use `sizes` attribute instead of `dims`
+* Added an error catch to remove RuntimeWarning in `gauss` function
 
 0.1.0 (2025-03-28)
 ------------------

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -72,4 +72,4 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: https://contributor-covenant.org
-[version]: https://contributor-covenant.org/version/1/4/
+[version]: https://www.contributor-covenant.org/version/1/4/code-of-conduct/

--- a/pyIntensityFeatures/_main.py
+++ b/pyIntensityFeatures/_main.py
@@ -374,7 +374,7 @@ class AuroralBounds(object):
         un_threshold : float
             Maximum acceptable uncertainty value in degrees (default=1.25)
         dayglow_threshold : float
-            Minimum allowable background intensity value in Rayleighs
+            Maximum allowable background intensity value in Rayleighs
             (default=300.0)
         strict_fit : bool
             Enforce positive values for the x-offsets in quadratic-Gaussian fits

--- a/pyIntensityFeatures/proc/intensity.py
+++ b/pyIntensityFeatures/proc/intensity.py
@@ -49,7 +49,7 @@ def find_intensity_boundaries(intensity, glat, glon, sweep_times, alt,
     un_threshold : float
         Maximum acceptable uncertainty value in degrees (default=1.25)
     dayglow_threshold : float
-        Minimum allowable background intensity value in Rayleighs (default=300)
+        Maximum allowable background intensity value in Rayleighs (default=300)
     strict_fit : bool
         Enforce positive values for the x-offsets in quadratic-Gaussian fits
         (default=False)

--- a/pyIntensityFeatures/tests/test_main.py
+++ b/pyIntensityFeatures/tests/test_main.py
@@ -273,7 +273,7 @@ class TestAuroralBounds(unittest.TestCase):
                              msg="unexpected default attributes")
         self.assertDictEqual({'sweep_start': 1, 'mlt': 48, 'coeff': 6,
                               'lat': 31, 'sweep_end': 1},
-                             dict(self.alb.boundaries.dims),
+                             dict(self.alb.boundaries.sizes),
                              msg="unexpected default dimensions")
         self.assertListEqual(["sweep_start", "sweep_end", "mlt", "hemisphere",
                               "lat"],
@@ -552,7 +552,7 @@ class TestAuroralBounds(unittest.TestCase):
                     self.inst_data = self.inst_data[:-10]
                 else:
                     self.inst_data = xr.Dataset({
-                        var: (self.inst_data[var].dims,
+                        var: (self.inst_data[var].sizes,
                               self.inst_data[var].values[:-10])
                         for var in [self.time_var, self.glat_var, self.glon_var,
                                     self.intensity_var, 'clean_flag']})

--- a/pyIntensityFeatures/tests/test_main.py
+++ b/pyIntensityFeatures/tests/test_main.py
@@ -215,8 +215,8 @@ class TestAuroralBounds(unittest.TestCase):
             end = pyIntensityFeatures.utils.coords.as_datetime(
                 self.inst_data[self.time_var].values[-1])
         else:
-            start = self.inst_data[self.time_var][0]
-            end = self.inst_data[self.time_var][-1]
+            start = list(self.inst_data[self.time_var])[0]
+            end = list(self.inst_data[self.time_var])[-1]
 
         # Evaluate the times
         self.assertTrue(self.alb.stime == start,

--- a/pyIntensityFeatures/tests/test_utils_checks.py
+++ b/pyIntensityFeatures/tests/test_utils_checks.py
@@ -900,9 +900,11 @@ class TestEvalBoundariesMLT(unittest.TestCase):
                                    checks.evaluate_boundary_in_mlt,
                                    *[self.bound_data, self.eq_key, self.po_key,
                                      self.lt_key, self.ut_key])
-        except AssertionError as aerr:
-            checks.evaluate_boundary_in_mlt(self.bound_data, self.eq_key, self.po_key, self.lt_key, self.ut_key)
-            
+        except AssertionError:
+            checks.evaluate_boundary_in_mlt(self.bound_data, self.eq_key,
+                                            self.po_key, self.lt_key,
+                                            self.ut_key)
+
         return
 
     def test_eval_success_no_removal(self):

--- a/pyIntensityFeatures/tests/test_utils_checks.py
+++ b/pyIntensityFeatures/tests/test_utils_checks.py
@@ -892,18 +892,13 @@ class TestEvalBoundariesMLT(unittest.TestCase):
         """Test raises ValueError with bad MLT coordinates."""
         # Update the MLT coordinates
         self.mlt[0] += 0.01
-        self.bound_data.assign({self.lt_key: self.mlt})
+        self.bound_data = self.bound_data.assign({self.lt_key: self.mlt})
 
         # Run and check the error
-        try:
-            self.assertRaisesRegex(ValueError, "not have a fixed frequency",
-                                   checks.evaluate_boundary_in_mlt,
-                                   *[self.bound_data, self.eq_key, self.po_key,
-                                     self.lt_key, self.ut_key])
-        except AssertionError:
-            checks.evaluate_boundary_in_mlt(self.bound_data, self.eq_key,
-                                            self.po_key, self.lt_key,
-                                            self.ut_key)
+        self.assertRaisesRegex(ValueError, "not have a fixed frequency",
+                               checks.evaluate_boundary_in_mlt,
+                               *[self.bound_data, self.eq_key, self.po_key,
+                                 self.lt_key, self.ut_key])
 
         return
 

--- a/pyIntensityFeatures/tests/test_utils_checks.py
+++ b/pyIntensityFeatures/tests/test_utils_checks.py
@@ -895,10 +895,14 @@ class TestEvalBoundariesMLT(unittest.TestCase):
         self.bound_data.assign({self.lt_key: self.mlt})
 
         # Run and check the error
-        self.assertRaisesRegex(ValueError, "not have a fixed frequency",
-                               checks.evaluate_boundary_in_mlt,
-                               *[self.bound_data, self.eq_key, self.po_key,
-                                 self.lt_key, self.ut_key])
+        try:
+            self.assertRaisesRegex(ValueError, "not have a fixed frequency",
+                                   checks.evaluate_boundary_in_mlt,
+                                   *[self.bound_data, self.eq_key, self.po_key,
+                                     self.lt_key, self.ut_key])
+        except AssertionError as aerr:
+            checks.evaluate_boundary_in_mlt(self.bound_data, self.eq_key, self.po_key, self.lt_key, self.ut_key)
+            
         return
 
     def test_eval_success_no_removal(self):

--- a/pyIntensityFeatures/tests/test_utils_output.py
+++ b/pyIntensityFeatures/tests/test_utils_output.py
@@ -121,7 +121,7 @@ class TestBoundaryDictFuncs(unittest.TestCase):
         for coord in self.coord_dict.keys():
             self.assertIn(coord, self.dataset.coords)
 
-            if coord in self.dataset.dims:
+            if coord in self.dataset.sizes:
                 if coord.find('sweep') < 0:
                     self.assertTrue(
                         np.all(self.dataset.coords[coord].values
@@ -399,7 +399,7 @@ class TestBoundaryDictFuncs(unittest.TestCase):
                                                     self.data_dict, 0)
 
         # Evalute the empty dataset
-        self.assertEqual(len(self.dataset.dims), 0)
+        self.assertEqual(len(self.dataset.sizes), 0)
         self.assertEqual(len(self.dataset.data_vars), 0)
         return
 

--- a/pyIntensityFeatures/utils/checks.py
+++ b/pyIntensityFeatures/utils/checks.py
@@ -194,7 +194,7 @@ def evaluate_dayglow(fit_coeff, locations, thresh=300.0):
     locations : array-like
         Locations at which the dayglow level will be evaluated.
     thresh : float
-        Minimum allowable background intensity value in Rayleighs (default=300)
+        Maximum allowable background intensity value in Rayleighs (default=300)
 
     Returns
     -------

--- a/pyIntensityFeatures/utils/distributions.py
+++ b/pyIntensityFeatures/utils/distributions.py
@@ -8,6 +8,8 @@
 
 import numpy as np
 
+import warnings
+
 
 def calc_quadratic(x, c, b, a):
     """Calculate the quadratic value at a specified location.
@@ -57,7 +59,10 @@ def gauss(x, amp, mu, sigma, const):
         Normal value at `x`
 
     """
-    y = amp * np.exp(-np.power((x - mu), 2.0) / (2.0 * sigma**2)) + const
+    if abs(sigma) > 0.0:
+        y = amp * np.exp(-np.power((x - mu), 2.0) / (2.0 * sigma**2)) + const
+    else:
+        y = np.zeros(shape=x.shape, dtype=float)
 
     return y
 

--- a/pyIntensityFeatures/utils/distributions.py
+++ b/pyIntensityFeatures/utils/distributions.py
@@ -8,8 +8,6 @@
 
 import numpy as np
 
-import warnings
-
 
 def calc_quadratic(x, c, b, a):
     """Calculate the quadratic value at a specified location.


### PR DESCRIPTION
# Description

Fixes the description of the `daylight_threshold` keyword arg variable in the docstrings.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

When running the code after a break, realized that the description was the opposite of what it should be.

## Test Configuration

- Operating system: OSX Tahoe
- Version number: Python 3.10
- Any details about your local setup that are relevant: N/A
# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My commits are formatted appropriately (following the SciPy/NumPy style) 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.md``, summarising the changes
- [x] Add yourself to ``.zenodo.json``
